### PR TITLE
[FraudAnalysis] Fix customer parser when fraud analysis is not configured

### DIFF
--- a/packages/checkout/core/src/services/charges/charges.utils.ts
+++ b/packages/checkout/core/src/services/charges/charges.utils.ts
@@ -36,7 +36,7 @@ export const formatFraudAnalysis = async (
   fraudAnalysis: FraudAnalysis,
   customer: Customer,
 ) => {
-  const currentCustomer = fraudAnalysis.customer || customer
+  const currentCustomer = fraudAnalysis?.customer || customer
 
   if (
     !fraudAnalysis ||


### PR DESCRIPTION
## Motivation

Today, when our own customer configures the checkout without fraud analysis and uses the customer object, the SDK crashes.

## Proposed solution

Fix customer parser when fraud analysis is not configured
