### PR TITLE
[Sessions] Fixed sessions without settings

### DIFF
--- a/packages/checkout/core/src/services/sessions/session.utils.ts
+++ b/packages/checkout/core/src/services/sessions/session.utils.ts
@@ -82,13 +82,13 @@ const getColorPalette = (color: string) => {
 export const normalizeCustomization = (data: Session) => {
   const settings = data.settings
 
-  const primaryColor = getColorPalette(settings.mainColor || '#344383')
-  const secondaryColor = getColorPalette(settings.secondaryColor || '#344383')
-  const errorColor = getColorPalette(settings.errorColor || '#FF1744')
-  const warningColor = getColorPalette(settings.attentionColor || '#FAC30E')
-  const successColor = getColorPalette(settings.successColor || '#32C000')
-  const backgroundColor = settings.backgroundColor || '#FFFFFF'
-  const brandUrl = settings.logo
+  const primaryColor = getColorPalette(settings?.mainColor || '#344383')
+  const secondaryColor = getColorPalette(settings?.secondaryColor || '#344383')
+  const errorColor = getColorPalette(settings?.errorColor || '#FF1744')
+  const warningColor = getColorPalette(settings?.attentionColor || '#FAC30E')
+  const successColor = getColorPalette(settings?.successColor || '#32C000')
+  const backgroundColor = settings?.backgroundColor || '#FFFFFF'
+  const brandUrl = settings?.logo
 
   return {
     brandUrl,

--- a/packages/checkout/core/src/services/sessions/sessions.types.ts
+++ b/packages/checkout/core/src/services/sessions/sessions.types.ts
@@ -18,11 +18,11 @@ export interface SessionNormalized extends Session {
 }
 
 export interface Session {
-  id: string
+  id?: string
   name: string
-  status: string
+  status?: string
   isActive: boolean
-  clientId: string
+  clientId?: string
   orderId?: string
   amount: number
   currency: string
@@ -38,12 +38,12 @@ export interface Session {
     quantity: number
     tangible?: boolean
   }[]
-  paymentLink: string
+  paymentLink?: string
   paymentMethods: PaymentMethod[]
-  createdAt: string
+  createdAt?: string
   updatedAt?: string
   publicKey?: string
-  settings: UserSettings
+  settings?: UserSettings
 }
 
 export interface UserSettings {


### PR DESCRIPTION
## Motivation (prefer a non-technical explanation)
Checkout did not show the payment information correctly when the setup session had no settings attribute. 

## Proposed solution (including technical details and their motivations)
Added null check to set the default settings values if it's null properly.
