### PR TITLE
[Transaction] Provider reference key

### DIFF
--- a/packages/checkout-full/core/src/components/malga-checkout-full/malga-checkout-full.tsx
+++ b/packages/checkout-full/core/src/components/malga-checkout-full/malga-checkout-full.tsx
@@ -79,6 +79,7 @@ export class MalgaCheckoutFull implements ComponentInterface {
     fraudAnalysis: null,
     paymentFlowMetadata: null,
     splitRules: null,
+    providerReferenceKey: null,
   }
   @Prop() dialogConfig: MalgaCheckoutFullDialog = {
     show: true,

--- a/packages/checkout-full/core/src/components/malga-checkout-full/malga-checkout-full.types.ts
+++ b/packages/checkout-full/core/src/components/malga-checkout-full/malga-checkout-full.types.ts
@@ -260,6 +260,7 @@ export interface MalgaCheckoutFullTransaction {
   fraudAnalysis?: MalgaCheckoutFullFraudAnalysis
   paymentFlowMetadata?: Record<string, unknown>
   splitRules?: MalgaCheckoutFullSplitRule[]
+  providerReferenceKey?: string
 }
 
 export interface MalgaCheckoutFullDialog {

--- a/packages/checkout/core/src/components/malga-checkout/malga-checkout.tsx
+++ b/packages/checkout/core/src/components/malga-checkout/malga-checkout.tsx
@@ -73,6 +73,7 @@ export class MalgaCheckout {
     fraudAnalysis: null,
     splitRules: null,
     paymentFlowMetadata: null,
+    providerReferenceKey: null,
   }
   @Prop() isLoading = false
   @Prop() appInfo?: AppInfo

--- a/packages/checkout/core/src/components/malga-checkout/malga-checkout.types.ts
+++ b/packages/checkout/core/src/components/malga-checkout/malga-checkout.types.ts
@@ -28,6 +28,7 @@ export interface MalgaCheckoutTransaction {
   fraudAnalysis?: FraudAnalysis
   splitRules?: SplitRule[]
   paymentFlowMetadata?: Record<string, unknown>
+  providerReferenceKey?: string
 }
 
 export interface MalgaCheckoutPaymentMethods {

--- a/packages/checkout/core/src/services/charges/charges.ts
+++ b/packages/checkout/core/src/services/charges/charges.ts
@@ -38,6 +38,7 @@ export class Charges {
       capture: settings.transactionConfig.capture,
       sessionId: settings.sessionId,
       splitRules: settings.transactionConfig.splitRules,
+      providerReferenceKey: settings.transactionConfig.providerReferenceKey,
       fraudAnalysis,
       ...(settings.transactionConfig.paymentFlowMetadata && {
         paymentFlow: {

--- a/packages/checkout/core/src/services/charges/charges.types.ts
+++ b/packages/checkout/core/src/services/charges/charges.types.ts
@@ -17,6 +17,7 @@ export interface CreateChargeData {
   fraudAnalysis?: FraudAnalysis
   paymentFlow?: Record<string, unknown>
   splitRules?: SplitRule[]
+  providerReferenceKey?: string
 }
 
 export interface FraudAnalysisCart {


### PR DESCRIPTION
## Motivation (prefer a non-technical explanation)
Enable our Checkout customers to send the new `providerReferenceKey` to create charges on Malga.

## Proposed solution (including technical details and their motivations)
I've created a new property inside `transactionConfig`, called `providerReferenceKey` and started sending it beside the charge payload.

## Observations (optional - any additional information you deem important)
The new Checkout API

```tsx
<MalgaCheckout
  publicKey="PUBLIC_KEY"
  clientId="CLIENT_ID"
  merchantId="MERCHANT_ID"
  paymentMethods={{
    credit: {
      installments: 1
    }
  }}
  transactionConfig={{
    statementDescriptor: '#1 Demonstration Malga Checkout',
    amount: 100,
    customerId: "CUSTOMER_ID",
    currency: 'BRL',
    capture: false,
    providerReferenceKey: "YOUR_PROVIDER_REFERENCE_ID"
  }}
  onPaymentSuccess={handlePaymentSuccess}
  onPaymentFailed={handlePaymentFailed}
/>
```
