### PR TITLE
[Idempotency Key] Change the value when an error occurs

### DIFF
--- a/packages/checkout/core/src/components/malga-checkout/malga-checkout.tsx
+++ b/packages/checkout/core/src/components/malga-checkout/malga-checkout.tsx
@@ -10,6 +10,8 @@ import {
   Watch,
 } from '@stencil/core'
 
+import { v4 as uuid } from 'uuid'
+
 import {
   clearEmptyObjectProperties,
   clearedObjectProperties,
@@ -93,6 +95,12 @@ export class MalgaCheckout {
 
   @State() isButtonLoading = false
 
+  @Watch('idempotencyKey')
+  protected handleWatchIdempotencyKey() {
+    settings.idempotencyKey = this.idempotencyKey
+    settings.automaticallyGeneratedIdempotencyKey = !this.idempotencyKey
+  }
+
   @Watch('transactionConfig')
   protected handleWatchTransactionConfig() {
     settings.transactionConfig = this.transactionConfig
@@ -136,7 +144,8 @@ export class MalgaCheckout {
     settings.publicKey = this.publicKey
     settings.sessionId = this.sessionId
     settings.merchantId = this.merchantId
-    settings.idempotencyKey = this.idempotencyKey
+    settings.idempotencyKey = this.idempotencyKey || uuid()
+    settings.automaticallyGeneratedIdempotencyKey = !this.idempotencyKey
     settings.locale = this.locale
     settings.sandbox = this.sandbox
     settings.debug = this.debug

--- a/packages/checkout/core/src/components/malga-payments-boleto/malga-payments-boleto.service.ts
+++ b/packages/checkout/core/src/components/malga-payments-boleto/malga-payments-boleto.service.ts
@@ -1,3 +1,5 @@
+import { v4 as uuid } from 'uuid'
+
 import { Boleto } from '../../providers/boleto'
 import { Charges } from '../../services/charges'
 
@@ -55,6 +57,10 @@ export class MalgaPaymentsBoletoService implements MalgaPayments {
   }
 
   handlePaymentFailed(error: MalgaPaymentsError) {
+    if (settings.automaticallyGeneratedIdempotencyKey) {
+      settings.idempotencyKey = uuid()
+    }
+
     if (settings.dialogConfig.show) {
       this.onShowDialog({
         open: true,

--- a/packages/checkout/core/src/components/malga-payments-credit/malga-payments-credit.service.ts
+++ b/packages/checkout/core/src/components/malga-payments-credit/malga-payments-credit.service.ts
@@ -1,3 +1,5 @@
+import { v4 as uuid } from 'uuid'
+
 import settings from '../../stores/settings'
 import payment from '../../stores/payment'
 import { handleSubmitValidation } from '../../stores/credit'
@@ -58,6 +60,10 @@ export class MalgaPaymentsCreditService implements MalgaPayments {
   }
 
   handlePaymentFailed(error: MalgaPaymentsError) {
+    if (settings.automaticallyGeneratedIdempotencyKey) {
+      settings.idempotencyKey = uuid()
+    }
+
     if (settings.dialogConfig.show) {
       this.onShowDialog({
         open: true,

--- a/packages/checkout/core/src/components/malga-payments-drip/malga-payments-drip.service.ts
+++ b/packages/checkout/core/src/components/malga-payments-drip/malga-payments-drip.service.ts
@@ -1,3 +1,5 @@
+import { v4 as uuid } from 'uuid'
+
 import settings from '../../stores/settings'
 import payment from '../../stores/payment'
 
@@ -45,6 +47,10 @@ export class MalgaPaymentsDripService implements MalgaPayments {
   }
 
   handlePaymentFailed(error: MalgaPaymentsError) {
+    if (settings.automaticallyGeneratedIdempotencyKey) {
+      settings.idempotencyKey = uuid()
+    }
+
     if (settings.dialogConfig.show) {
       this.onShowDialog({
         open: true,

--- a/packages/checkout/core/src/components/malga-payments-nupay/malga-payments-nupay.service.ts
+++ b/packages/checkout/core/src/components/malga-payments-nupay/malga-payments-nupay.service.ts
@@ -1,3 +1,5 @@
+import { v4 as uuid } from 'uuid'
+
 import settings from '../../stores/settings'
 import payment from '../../stores/payment'
 
@@ -49,6 +51,10 @@ export class MalgaPaymentsNuPayService implements MalgaPayments {
   }
 
   handlePaymentFailed(error: MalgaPaymentsError) {
+    if (settings.automaticallyGeneratedIdempotencyKey) {
+      settings.idempotencyKey = uuid()
+    }
+
     if (settings.dialogConfig.show) {
       this.onShowDialog({
         open: true,

--- a/packages/checkout/core/src/components/malga-payments-pix/malga-payments-pix.service.ts
+++ b/packages/checkout/core/src/components/malga-payments-pix/malga-payments-pix.service.ts
@@ -1,3 +1,5 @@
+import { v4 as uuid } from 'uuid'
+
 import payment from '../../stores/payment'
 import settings from '../../stores/settings'
 
@@ -58,6 +60,10 @@ export class MalgaPaymentsPixService implements MalgaPayments {
   }
 
   handlePaymentFailed(error: MalgaPaymentsError) {
+    if (settings.automaticallyGeneratedIdempotencyKey) {
+      settings.idempotencyKey = uuid()
+    }
+
     if (settings.dialogConfig.show) {
       this.onShowDialog({
         open: true,

--- a/packages/checkout/core/src/stores/settings/settings.ts
+++ b/packages/checkout/core/src/stores/settings/settings.ts
@@ -1,13 +1,13 @@
 import { createStore } from '@stencil/store'
-import { v4 as uuidV4 } from 'uuid'
 
 import { SettingsState } from './settings.types'
 
-export const { state, onChange } = createStore<SettingsState>({
+export const { state } = createStore<SettingsState>({
   clientId: '',
   publicKey: '',
   sessionId: '',
   merchantId: '',
+  automaticallyGeneratedIdempotencyKey: true,
   idempotencyKey: '',
   locale: undefined,
   sandbox: false,
@@ -35,8 +35,4 @@ export const { state, onChange } = createStore<SettingsState>({
     splitRules: null,
   },
   appInfo: undefined,
-})
-
-onChange('idempotencyKey', (value) => {
-  state.idempotencyKey = value || uuidV4()
 })

--- a/packages/checkout/core/src/stores/settings/settings.types.ts
+++ b/packages/checkout/core/src/stores/settings/settings.types.ts
@@ -10,6 +10,7 @@ export interface SettingsState {
   clientId: string
   publicKey: string
   sessionId?: string
+  automaticallyGeneratedIdempotencyKey: boolean
   idempotencyKey: string
   merchantId: string
   locale?: Locale


### PR DESCRIPTION
## Motivation 

When the user received an error in the charges request, the idempotency key was not updated, causing any new request for charges to always return the same response.

## Proposed solution

A treatment was added to determine when an `idempotencyKey` was generated automatically or added by the SDK settings. Therefore, when it is generated automatically and an error occurs in the charges request, its value will be updated.

For cases where the client passes an idempotencyKey, its handling is the client's responsibility, requiring manual updating of the value in the onPaymentFailed event.

## Observations

It was also necessary to add an observer to the `idempotencyKey` property of the SDK, so that we don't have inconsistency between the property and the value stored in the application's global store.