### PR TITLE
[Pix-Boleto] Add items object in Pix and Boleto payment method.

### DIFF
--- a/packages/checkout/core/src/providers/boleto/boleto.ts
+++ b/packages/checkout/core/src/providers/boleto/boleto.ts
@@ -6,7 +6,7 @@ import {
 } from './boleto.types'
 
 import settings from '../../stores/settings'
-import { normalizeBoletoFees } from './boleto.utils'
+import { getItems, normalizeBoletoFees } from './boleto.utils'
 
 export class Boleto extends BaseProvider {
   readonly boleto: BoletoAttributes
@@ -20,12 +20,15 @@ export class Boleto extends BaseProvider {
   }
 
   public getPaymentMethod(): PaymentMethodBoleto {
+    const items = getItems(this.boleto)
+
     return {
       paymentType: 'boleto',
       expiresDate: this.boleto.expiresDate,
       instructions: this.boleto.instructions,
       ...normalizeBoletoFees('interest', this.boleto.interest),
       ...normalizeBoletoFees('fine', this.boleto.fine),
+      ...items,
     }
   }
 }

--- a/packages/checkout/core/src/providers/boleto/boleto.types.ts
+++ b/packages/checkout/core/src/providers/boleto/boleto.types.ts
@@ -1,3 +1,5 @@
+import { MalgaPaymentsItem } from '../../types/malga-payments-items.types'
+
 export interface BoletoAttributes {
   expiresDate: string
   instructions: string
@@ -11,6 +13,7 @@ export interface BoletoAttributes {
     amount?: number
     percentage?: number
   }
+  items?: MalgaPaymentsItem[] | null
 }
 
 export interface PaymentMethodBoleto extends BoletoAttributes {

--- a/packages/checkout/core/src/providers/boleto/boleto.utils.ts
+++ b/packages/checkout/core/src/providers/boleto/boleto.utils.ts
@@ -1,3 +1,13 @@
+import type { BoletoAttributes } from './boleto.types'
+
+export const getItems = (boleto: BoletoAttributes) => {
+  if (!boleto.items || !boleto.items?.length) return {}
+
+  return {
+    items: boleto.items,
+  }
+}
+
 export const normalizeBoletoFees = (feesType, fees) => {
   return fees ? { [feesType]: formatBoletoFees(fees) } : {}
 }

--- a/packages/checkout/core/src/providers/drip/drip.types.ts
+++ b/packages/checkout/core/src/providers/drip/drip.types.ts
@@ -1,9 +1,4 @@
-interface DripAttributesItem {
-  id: string
-  quantity: number
-  title: string
-  unitPrice: number
-}
+import { MalgaPaymentsItem } from '../../types/malga-payments-items.types'
 
 interface DripAttributesBrowser {
   ipAddress: string
@@ -11,7 +6,7 @@ interface DripAttributesBrowser {
 }
 
 export interface DripAttributes {
-  items?: DripAttributesItem[] | null
+  items?: MalgaPaymentsItem[] | null
   browser?: DripAttributesBrowser | null
   successRedirectUrl?: string
   cancelRedirectUrl?: string

--- a/packages/checkout/core/src/providers/drip/drip.utils.ts
+++ b/packages/checkout/core/src/providers/drip/drip.utils.ts
@@ -1,6 +1,6 @@
 import { DripAttributes } from './drip.types'
 
-export const getBrowser = (drip: DripAttributes) => {
+export const getItems = (drip: DripAttributes) => {
   if (!drip.items || !drip.items?.length) return {}
 
   return {
@@ -8,7 +8,7 @@ export const getBrowser = (drip: DripAttributes) => {
   }
 }
 
-export const getItems = (drip: DripAttributes) => {
+export const getBrowser = (drip: DripAttributes) => {
   if (!drip.browser) return {}
 
   return {

--- a/packages/checkout/core/src/providers/pix/pix.ts
+++ b/packages/checkout/core/src/providers/pix/pix.ts
@@ -2,6 +2,7 @@ import { BaseProvider } from '../base-provider'
 import { PixAttributes, PaymentMethodPix, PixConstructor } from './pix.types'
 
 import settings from '../../stores/settings'
+import { getItems } from './pix.utils'
 
 export class Pix extends BaseProvider {
   readonly pix: PixAttributes
@@ -15,9 +16,12 @@ export class Pix extends BaseProvider {
   }
 
   public getPaymentMethod(): PaymentMethodPix {
+    const items = getItems(this.pix)
+
     return {
       paymentType: 'pix',
       expiresIn: this.pix.expiresIn,
+      ...items,
     }
   }
 }

--- a/packages/checkout/core/src/providers/pix/pix.types.ts
+++ b/packages/checkout/core/src/providers/pix/pix.types.ts
@@ -1,10 +1,12 @@
+import { MalgaPaymentsItem } from '../../types/malga-payments-items.types'
+
 export interface PixAttributes {
   expiresIn: number
+  items?: MalgaPaymentsItem[] | null
 }
 
-export interface PaymentMethodPix {
+export interface PaymentMethodPix extends PixAttributes {
   paymentType: 'pix'
-  expiresIn: number
 }
 
 export interface PixConstructor {

--- a/packages/checkout/core/src/providers/pix/pix.utils.ts
+++ b/packages/checkout/core/src/providers/pix/pix.utils.ts
@@ -1,0 +1,9 @@
+import type { PixAttributes } from './pix.types'
+
+export const getItems = (pix: PixAttributes) => {
+  if (!pix.items || !pix.items?.length) return {}
+
+  return {
+    items: pix.items,
+  }
+}

--- a/packages/checkout/core/src/types/malga-payments-items.types.ts
+++ b/packages/checkout/core/src/types/malga-payments-items.types.ts
@@ -1,0 +1,6 @@
+export interface MalgaPaymentsItem {
+  id: string
+  quantity: number
+  title: string
+  unitPrice: number
+}


### PR DESCRIPTION
## Motivation (prefer a non-technical explanation)
Adjustments to receive the items object on pix and boleto payments.

## Proposed solution (including technical details and their motivations)
- Create the MalgaAtributtesItems to use on Drip,Pix and Boleto.
- Update the configurations of these payments to receive this items.

## Observations (optional - any additional information you deem important)
Fixed the getBrowser and getItems on Drip payment method. 

