### PR TITLE
[Mobile] Fixed the responsible credit payment fields

### DIFF
--- a/packages/checkout/core/src/components/malga-payments-credit/partials/malga-payments-credit-form/malga-payments-credit-form.scss
+++ b/packages/checkout/core/src/components/malga-payments-credit/partials/malga-payments-credit-form/malga-payments-credit-form.scss
@@ -10,11 +10,11 @@
   width: 100%;
 
   & > checkout-text-field {
-    margin-top: var(--malga-checkout-spacing-xs);
+    margin-top: var(--malga-checkout-spacing-sm);
   }
 
   & > checkout-select-field {
-    margin-top: var(--malga-checkout-spacing-xs);
+    margin-top: var(--malga-checkout-spacing-sm);
   }
 }
 
@@ -22,13 +22,13 @@
   display: flex;
   flex-direction: column;
   align-self: center;
-  margin-top: var(--malga-checkout-spacing-xs);
+  margin-top: var(--malga-checkout-spacing-sm);
   padding: 0px;
   margin: 0px;
 
   @media screen and (min-width: 768px) {
     flex-direction: row;
-    gap: var(--malga-checkout-spacing-xs);
+    gap: var(--malga-checkout-spacing-sm);
   }
 
 }
@@ -40,7 +40,7 @@
   border: none;
   padding: 0;
   margin: 0;
-  margin-top: var(--malga-checkout-spacing-xs);
+  margin-top: var(--malga-checkout-spacing-sm);
   gap: var(--malga-checkout-spacing-xs);
 
 }
@@ -50,7 +50,7 @@
   flex-direction: row;
   align-items: center;
   margin-top: var(--malga-checkout-spacing-default);
-  margin-bottom: var(--malga-checkout-spacing-xs);
+  margin-bottom: var(--malga-checkout-spacing-sm);
 
   & > checkout-typography {
     font-weight: 400;

--- a/packages/checkout/core/src/components/malga-payments-credit/partials/malga-payments-credit-form/malga-payments-credit-form.scss
+++ b/packages/checkout/core/src/components/malga-payments-credit/partials/malga-payments-credit-form/malga-payments-credit-form.scss
@@ -18,22 +18,31 @@
   }
 }
 
-.malga-payments-credit-form__row-fields {
+.malga-payments-credit-form__container {
   display: flex;
-  flex-direction: row;
-  align-items: center;
-  border: none;
-  margin: 0px;
+  flex-direction: column;
+  align-self: center;
   margin-top: var(--malga-checkout-spacing-xs);
   padding: 0px;
+  margin: 0px;
 
-  & > checkout-text-field:first-child {
-    margin-right: var(--malga-checkout-spacing-xs);
+  @media screen and (min-width: 768px) {
+    flex-direction: row;
+    gap: var(--malga-checkout-spacing-xs);
   }
 
-  & > checkout-text-field:last-child {
-    margin-left: var(--malga-checkout-spacing-xs);
-  }
+}
+
+.malga-payments-credit-form__column-fields {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  border: none;
+  padding: 0;
+  margin: 0;
+  margin-top: var(--malga-checkout-spacing-xs);
+  gap: var(--malga-checkout-spacing-xs);
+
 }
 
 .malga-payments-credit-form__save-card {

--- a/packages/checkout/core/src/components/malga-payments-credit/partials/malga-payments-credit-form/malga-payments-credit-form.tsx
+++ b/packages/checkout/core/src/components/malga-payments-credit/partials/malga-payments-credit-form/malga-payments-credit-form.tsx
@@ -139,56 +139,62 @@ export class MalgaPaymentsCreditForm implements ComponentInterface {
                 message={credit.validations.fields.cardNumber}
               />
             )}
-
-          <fieldset class="malga-payments-credit-form__row-fields">
-            <checkout-text-field
-              value={credit.form.expirationDate}
-              onChanged={this.handleFieldChange('expirationDate')}
-              onBlurred={this.handleValidationField('expirationDate')}
-              onFocused={this.handleFieldFocused('expirationDate')}
-              onPaste={this.handleFieldChange('expirationDate')}
-              fullWidth
-              inputmode="numeric"
-              hasValidation={credit.validations.fields.expirationDate !== null}
-              hasError={!!credit.validations.fields.expirationDate}
-              name="expirationDate"
-              label={t(
-                'paymentMethods.card.newCard.fields.expirationDate.label',
-                settings.locale,
-              )}
-              mask="99/99"
-            />
-
-            <checkout-text-field
-              value={credit.form.cvv}
-              onChanged={this.handleFieldChange('cvv')}
-              onBlurred={this.handleValidationField('cvv')}
-              onFocused={this.handleFieldFocused('cvv')}
-              onPaste={this.handleFieldChange('cvv')}
-              fullWidth
-              inputmode="numeric"
-              hasValidation={credit.validations.fields.cvv !== null}
-              hasError={!!credit.validations.fields.cvv}
-              name="cvv"
-              label={t(
-                'paymentMethods.card.newCard.fields.cvv.label',
-                settings.locale,
-              )}
-              mask="9999"
-            />
-          </fieldset>
-          {!credit.validations.allFieldsIsBlank &&
-            !!credit.validations.fields.expirationDate && (
-              <checkout-error-message
-                message={credit.validations.fields.expirationDate}
+          <div class="malga-payments-credit-form__container">
+            <fieldset class="malga-payments-credit-form__column-fields">
+              <checkout-text-field
+                value={credit.form.expirationDate}
+                onChanged={this.handleFieldChange('expirationDate')}
+                onBlurred={this.handleValidationField('expirationDate')}
+                onFocused={this.handleFieldFocused('expirationDate')}
+                onPaste={this.handleFieldChange('expirationDate')}
+                fullWidth
+                inputmode="numeric"
+                hasValidation={
+                  credit.validations.fields.expirationDate !== null
+                }
+                hasError={!!credit.validations.fields.expirationDate}
+                name="expirationDate"
+                label={t(
+                  'paymentMethods.card.newCard.fields.expirationDate.label',
+                  settings.locale,
+                )}
+                mask="99/99"
               />
-            )}
-
-          {!credit.validations.allFieldsIsBlank &&
-            !!credit.validations.fields.cvv && (
-              <checkout-error-message message={credit.validations.fields.cvv} />
-            )}
-
+              {!credit.validations.allFieldsIsBlank &&
+                !!credit.validations.fields.expirationDate && (
+                  <checkout-error-message
+                    style={{ marginTop: '0px' }}
+                    message={credit.validations.fields.expirationDate}
+                  />
+                )}
+            </fieldset>
+            <fieldset class="malga-payments-credit-form__column-fields">
+              <checkout-text-field
+                value={credit.form.cvv}
+                onChanged={this.handleFieldChange('cvv')}
+                onBlurred={this.handleValidationField('cvv')}
+                onFocused={this.handleFieldFocused('cvv')}
+                onPaste={this.handleFieldChange('cvv')}
+                fullWidth
+                inputmode="numeric"
+                hasValidation={credit.validations.fields.cvv !== null}
+                hasError={!!credit.validations.fields.cvv}
+                name="cvv"
+                label={t(
+                  'paymentMethods.card.newCard.fields.cvv.label',
+                  settings.locale,
+                )}
+                mask="9999"
+              />
+              {!credit.validations.allFieldsIsBlank &&
+                !!credit.validations.fields.cvv && (
+                  <checkout-error-message
+                    style={{ marginTop: '0px' }}
+                    message={credit.validations.fields.cvv}
+                  />
+                )}
+            </fieldset>
+          </div>
           <checkout-text-field
             value={credit.form.name.toUpperCase()}
             onChanged={this.handleFieldChange('name')}


### PR DESCRIPTION
## Motivation (prefer a non-technical explanation)
The placeholders were overlapping the text field container in the credit card payments on mobile.

## Proposed solution (including technical details and their motivations)
Adjusted so that on mobile and smaller screens, it uses flex direction column.
