### PR TITLE
fix(zipcode-validator): fixing wrong intl path

### DIFF
--- a/packages/checkout-full/core/src/components/malga-checkout-full/partials/malga-checkout-full-identification/malga-checkout-full-identification.schema.ts
+++ b/packages/checkout-full/core/src/components/malga-checkout-full/partials/malga-checkout-full-identification/malga-checkout-full-identification.schema.ts
@@ -113,7 +113,7 @@ export const schema = (locale?: Locale) => {
       .test(
         'isValidZipcode',
         t(
-          'page.customer.fields.identification.errorMessageInvalidZipCodeFormat',
+          'page.customer.fields.zipCode.errorMessageInvalidZipCodeFormat',
           locale,
         ),
         (value, context) => {
@@ -124,10 +124,7 @@ export const schema = (locale?: Locale) => {
       )
       .test(
         'isValidCountry',
-        t(
-          'page.customer.fields.identification.errorMessageRequiredCountry',
-          locale,
-        ),
+        t('page.customer.fields.zipCode.errorMessageRequiredCountry', locale),
         (value, context) => {
           if (value.length === 0) return true
 


### PR DESCRIPTION
## Motivation (prefer a non-technical explanation)
We were accessing the translation using the wrong path.

## Proposed solution (including technical details and their motivations)
Changing to the right path.
