### PR TITLE
feat(installments): adding a way to set up installments without having the UI

### DIFF
--- a/packages/checkout/core/src/components/malga-checkout/malga-checkout.service.ts
+++ b/packages/checkout/core/src/components/malga-checkout/malga-checkout.service.ts
@@ -78,8 +78,6 @@ export class MalgaCheckoutService {
       nupay: MalgaPaymentsNuPayService,
     }
 
-    console.log(payment.selectedPaymentMethod)
-
     return (
       paymentMethods[payment.selectedPaymentMethod] || paymentMethods.credit
     )
@@ -175,8 +173,6 @@ export class MalgaCheckoutService {
   }
 
   public async pay() {
-    console.log('inferno')
-
     const PaymentMethodClass = this.handlePaymentMethod()
     const paymentMethodData = this.handlePaymentData()
 


### PR DESCRIPTION
## Motivation (prefer a non-technical explanation)
Our customers have been requesting a way to manually set up credit installments, bypassing the need for users to fill out the installments UI themselves.

## Proposed solution (including technical details and their motivations)
Now you can set up both behaviors using the same installment object!

- `show` property as `false`: our Checkout won't show the installments UI and will send the `quantity` prop as the installments value;
- `show` property as `true`: our Checkout will show the installments UI and `quantity` property will be the number of options available for the user.

```typescript
malgaCheckout.paymentMethods = {
  credit: {
    installments: {
      quantity: 10,
      show: false,
    },
    showCreditCard: true,
  }
}
```
