### PR TITLE
fix(installments): fixing installments feat when only one method was set up

### DIFF
--- a/packages/checkout/core/src/components/malga-checkout/malga-checkout.service.ts
+++ b/packages/checkout/core/src/components/malga-checkout/malga-checkout.service.ts
@@ -28,12 +28,12 @@ export class MalgaCheckoutService {
 
   private handleCreditPaymentData = () => {
     const isShowingInstallmentSelector =
-      settings.paymentMethods.credit.installments.show
+      settings.paymentMethods.credit?.installments?.show
 
     if (payment.isSelectedSavedCard) {
       const installments = isShowingInstallmentSelector
         ? payment.installments
-        : settings.paymentMethods.credit.installments.quantity
+        : settings.paymentMethods.credit?.installments?.quantity
 
       return {
         cardId: payment.cardId,
@@ -44,7 +44,7 @@ export class MalgaCheckoutService {
 
     const installments = isShowingInstallmentSelector
       ? credit.form.installments
-      : settings.paymentMethods.credit.installments.quantity
+      : settings.paymentMethods.credit?.installments?.quantity
 
     return {
       ...credit.form,


### PR DESCRIPTION
## Motivation (prefer a non-technical explanation)
Checkout is broken when you set up only one method. 

## Proposed solution (including technical details and their motivations)
Because even when u are not using credit as method, the handleCreditPaymentData function is always called, so when u don't have installments it throws null access error.