### PR TITLE
[Intl] Change the field zip code and add new information

### DIFF
--- a/packages/i18n/src/configs/pt/translations.json
+++ b/packages/i18n/src/configs/pt/translations.json
@@ -223,7 +223,7 @@
           "errorMessageRequiredBrazil": "CEP é obrigatório.",
           "errorMessageInvalidZipCodeFormat": "Digite um CEP válido",
           "errorMessageRequiredCountry": "Selecione um país",
-          "labelInternational": "Código postal",
+          "labelInternational": "Código postal (CEP)",
           "errorMessageRequiredInternational": "Código postal é obrigatório."
         },
         "street": {

--- a/packages/i18n/src/configs/translations.json
+++ b/packages/i18n/src/configs/translations.json
@@ -223,7 +223,7 @@
           "errorMessageRequiredBrazil": "CEP é obrigatório.",
           "errorMessageInvalidZipCodeFormat": "Digite um CEP válido",
           "errorMessageRequiredCountry": "Selecione um país",
-          "labelInternational": "Código postal",
+          "labelInternational": "Código postal (CEP)",
           "errorMessageRequiredInternational": "Código postal é obrigatório."
         },
         "street": {


### PR DESCRIPTION
## Motivation (prefer a non-technical explanation)
To help the clients know that "Código postal" its the same like "CEP".
