### PR TITLE
release(fraud-analysis-customer): stopping to send identity type when it's no document

### DIFF
--- a/.changeset/brown-coins-drop.md
+++ b/.changeset/brown-coins-drop.md
@@ -1,0 +1,12 @@
+---
+'@malga-checkout/core': patch
+'@malga-checkout-full/angular': patch
+'@malga-checkout-full/core': patch
+'@malga-checkout-full/react': patch
+'@malga-checkout-full/vue': patch
+'@malga-checkout/angular': patch
+'@malga-checkout/react': patch
+'@malga-checkout/vue': patch
+---
+
+stopping to send identity type when it's no document


### PR DESCRIPTION
### **User description**
## Motivation (prefer a non-technical explanation)
To prevent new errors, we'll stop to send the identity type on fraudAnalysis when it's set up as "noDocument".

