### PR TITLE
revert: revert pt translations

### DIFF
--- a/packages/i18n/src/configs/pt/translations.json
+++ b/packages/i18n/src/configs/pt/translations.json
@@ -25,31 +25,27 @@
         },
         "fields": {
           "cardNumber": {
-            "label": "Número do cartão",
+            "label": "Número do cartão *",
             "errorMessageRequired": "Número do cartão é obrigatório.",
-            "errorMessageMin": "Número do cartão incompleto.",
-            "errorMessageInvalidFormat": "Número do cartão inválido."
+            "errorMessageInvalidFormat": "Formato inválido, verifique os dados do cartão."
           },
           "expirationDate": {
-            "label": "Expiração (MM/AA)",
+            "label": "Data de expiração (MM/AA) *",
             "errorMessageRequired": "Validade é obrigatória.",
-            "errorMessageMin": "Data de expiração incompleta.",
-            "errorMessageMonthInvalid": "Data de expiração inválida.",
-            "errorMessageInvalidFormat": "Cartão vencido."
+            "errorMessageInvalidFormat": "Data inválida, verifique os dados do cartão."
           },
           "cvv": {
-            "label": "CVV",
+            "label": "Código de segurança (CVV) *",
             "errorMessageRequired": "CVV é obrigatório.",
-            "errorMessageMin": "CVV incompleto.",
-            "errorMessageInvalidFormat": "CVV inválido."
+            "errorMessageInvalidFormat": "Formato inválido, verifique os dados do cartão."
           },
           "name": {
-            "label": "Nome do titular do cartão",
-            "errorMessageRequired": "Nome do titular é obrigatório.",
-            "errorMessageInvalidFormat": "Nome inválido."
+            "label": "Nome no cartão *",
+            "errorMessageRequired": "Portador do cartão é obrigatório.",
+            "errorMessageInvalidFormat": "Formato inválido, verifique os dados do cartão."
           },
           "installments": {
-            "label": "Parcelamento",
+            "label": "Parcelamento *",
             "errorMessageRequired": "Selecione uma parcela para prosseguir."
           },
           "saveCard": {
@@ -62,11 +58,11 @@
         "fields": {
           "cvv": {
             "description": "Para efetuar sua transação de forma segura, informe o CVV presente no verso do seu cartão.",
-            "label": "Código de segurança (CVV)",
+            "label": "Código de segurança (CVV) *",
             "errorMessage": "Formato inválido, verifique os dados do cartão."
           },
           "installments": {
-            "label": "Parcelamento",
+            "label": "Parcelamento *",
             "errorMessage": "Parcelamento é obrigatório."
           }
         }
@@ -109,7 +105,7 @@
       "title": "PIX parcelado + cashback",
       "descriptions": {
         "first": "São 3 passos simples para ter sua",
-       "second": "compra confirmada em {installments}x no PIX parcelado, zero juros, cashback",
+        "second": "compra confirmada em 3x no PIX parcelado, zero juros, cashback",
         "third": "e dependendo do seu perfil, com ou sem pagamento de entrada."
       },
       "installments": {
@@ -191,38 +187,33 @@
       "submitButton": "Próximo",
       "fields": {
         "name": {
-          "label": "Nome completo",
-          "errorMessageRequired": "Nome é obrigatório",
-          "errorMessageInvalidFormat": "Nome inválido."
+          "label": "Nome completo *",
+          "errorMessageRequired": "Nome completo é obrigatório.",
+          "errorMessageInvalidFormat": "Data inválida, verifique os dados do cartão."
         },
         "email": {
-          "label": "E-mail",
+          "label": "E-mail *",
           "errorMessageRequired": "E-mail é obrigatório.",
-          "errorMessageInvalidFormat": "Email inválido."
+          "errorMessageInvalidFormat": "Formato inválido, verifique seu e-mail."
         },
         "phoneNumber": {
-          "label": "Telefone",
+          "label": "Telefone *",
           "errorMessageRequired": "Telefone é obrigatório.",
           "errorMessageInvalidFormat": "Formato inválido, verifique o seu número de telefone."
         },
         "documentCountry": {
-          "label": "País do documento",
-          "errorMessageRequired": "País é obrigatório."
+          "label": "País do documento *",
+          "errorMessageRequired": "Selecione um país para continuar."
         },
         "documentType": {
-          "label": "Tipo do documento",
-          "errorMessageRequired": "Tipo do documento é obrigatório."
+          "label": "Tipo do documento *",
+          "errorMessageRequired": "Selecione um tipo de documento para continuar."
         },
         "identification": {
-          "labelBrazil": "CPF/CNPJ",
-          "errorMessageRequiredBrazil": "Número do documento é obrigatório.",
-          "errorMessageInvalidCpf": "CPF inválido.",
-          "errorMessageInvalidCnpj": "CNPJ inválido.",
-          "errorInvalidNationalDocument": "Seu documento está incompleto.",
-          "errorRequiredCountry": "Selecione um país.",
-          "errorRequiredType": "Selecione o tipo do documento.",
-          "errorRequiredCountryAndType": "Selecione o país e o tipo do documento.",
-          "labelInternational": "Número do documento",
+          "labelBrazil": "CPF/CNPJ *",
+          "errorMessageRequiredBrazil": "CPF ou CNPJ é obrigatório.",
+          "errorMessageInvalidFormatBrazil": "Formato inválido, verifique seu CPF ou CNPJ.",
+          "labelInternational": "Número do documento *",
           "errorMessageRequiredInternational": "Número do documento é obrigatório.",
           "errorMessageInvalidFormatInternational": "Formato inválido, verifique o seu documento."
         },
@@ -230,10 +221,10 @@
           "labelBrazil": "CEP",
           "descriptionBrazil": "Não sei meu CEP",
           "errorMessageRequiredBrazil": "CEP é obrigatório.",
+          "errorMessageInvalidZipCodeFormat": "Digite um CEP válido",
+          "errorMessageRequiredCountry": "Selecione um país",
           "labelInternational": "Código postal (CEP)",
-          "errorMessageRequiredInternational": "Código postal é obrigatório.",
-          "errorMessageInvalidZipCodeFormat": "Código postal inválido.",
-          "errorMessageRequiredCountry": "Selecione um país"
+          "errorMessageRequiredInternational": "Código postal é obrigatório."
         },
         "street": {
           "label": "Endereço",
@@ -244,7 +235,8 @@
           "errorMessageRequired": "Número é obrigatório."
         },
         "complement": {
-          "label": "Complemento (opcional)"
+          "label": "Complemento",
+          "errorMessageRequired": "Complemento é obrigatório."
         },
         "neighborhood": {
           "label": "Bairro",
@@ -260,7 +252,7 @@
         },
         "country": {
           "label": "País",
-          "errorMessageRequired": "País é obrigatório."
+          "errorMessageRequired": "Selecione um país para continuar."
         }
       }
     }


### PR DESCRIPTION
### **User description**
revertendo as traduções do arquivo pt para pushar novamente em seguida a branch translations/*.


___

### **PR Type**
Other


___

### **Description**
- Revert Portuguese translations to previous version

- Simplify error messages and field labels

- Remove specific validation messages

- Standardize field label formatting with asterisks


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Current PT translations"] --> B["Revert changes"] --> C["Previous PT translations"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Other</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>translations.json</strong><dd><code>Revert Portuguese translation changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/i18n/src/configs/pt/translations.json

<li>Revert field labels to include asterisks for required fields<br> <li> Simplify error messages to generic format validation text<br> <li> Remove specific validation messages for card fields<br> <li> Standardize error message wording across form fields


</details>


  </td>
  <td><a href="https://github.com/plughacker/malga-checkout/pull/175/files#diff-41697484f063e363b88c06541cd7eb0e6272bd1d57438114c21817983d5a5c15">+33/-41</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>